### PR TITLE
Add after_migrate hook for customer_links in smartpractices/utils/after_migrate.py

### DIFF
--- a/smartpractices/hooks.py
+++ b/smartpractices/hooks.py
@@ -67,9 +67,9 @@ doctype_js = {
 # 	"filters": "smartpractices.utils.jinja_filters"
 # }
 
-#after_migrate = [
-#    "smartpractices.utils.after_migrate.import_item_groups",
-#    ]
+after_migrate = [
+    "smartpractices.utils.after_migrate.customer_links",
+]
 
 # Installation
 # ------------

--- a/smartpractices/utils/after_migrate.py
+++ b/smartpractices/utils/after_migrate.py
@@ -1,8 +1,16 @@
 import frappe
 
-def import_item_groups():
-	# Check if Item Group "Smart Practices" exists. If exists return else create it
-	if frappe.db.exists("Item Group", "Smart Practices"):
-		return
-	
-	pass
+def customer_links():
+	# Check "DocType Link" if there is entry for link_doctype with value "Register Company"
+	if not frappe.db.exists("DocType Link", {"link_doctype": "Register Company", "parent": "Company"}):
+		# Create a new entry in "DocType Link" with link_doctype "Register Company"
+		frappe.get_doc({
+			"doctype": "DocType Link",
+			"link_doctype": "Register Company",
+			"link_fieldname": "company",
+			"parenttype": "Customize Form",
+			"parent": "Company",
+			"parentfield": "links",
+			"group": "Orders",
+			"custom": 1
+		}).insert()

--- a/smartpractices/utils/after_migrate.py
+++ b/smartpractices/utils/after_migrate.py
@@ -2,14 +2,14 @@ import frappe
 
 def customer_links():
 	# Check "DocType Link" if there is entry for link_doctype with value "Register Company"
-	if not frappe.db.exists("DocType Link", {"link_doctype": "Register Company", "parent": "Company"}):
+	if not frappe.db.exists("DocType Link", {"link_doctype": "Register Company", "parent": "Customer"}):
 		# Create a new entry in "DocType Link" with link_doctype "Register Company"
 		frappe.get_doc({
 			"doctype": "DocType Link",
 			"link_doctype": "Register Company",
-			"link_fieldname": "company",
+			"link_fieldname": "customer",  # Assuming "Register Company" DocType has a link field to "Customer"
 			"parenttype": "Customize Form",
-			"parent": "Company",
+			"parent": "Customer",
 			"parentfield": "links",
 			"group": "Orders",
 			"custom": 1


### PR DESCRIPTION
This pull request adds an after_migrate hook for the customer_links function in the smartpractices/utils/after_migrate.py file. The hook checks if there is an entry for link_doctype with the value "Register Company" in the "DocType Link" table. If not, it creates a new entry with the link_doctype set to "Register Company" and the link_fieldname set to "customer". This hook is intended to be used during the migration process.